### PR TITLE
Fixed async usage to only invoke LogicalDevice.search callback when a…

### DIFF
--- a/lib/logicalDevice.js
+++ b/lib/logicalDevice.js
@@ -100,13 +100,18 @@ var search = function(callback) {
           return new LogicalDevice(group.members, group.coordinator);
         });
 
-        async.forEach(logicalDevices, function(device) {
+        async.forEach(logicalDevices, function(device, done) {
           device.initialize(function(err) {
-            if (err) callback(err);
+            if (err) done(err);
             else {
-              callback(null, logicalDevices);
+              done(null);
             }
           });
+        }, function(err) {
+          if (err) callback(err);
+          else {
+            callback(null, logicalDevices);
+          }
         });
       }
 


### PR DESCRIPTION
…ll device initializations have completed.

The async.each usage here is causing the LogicalDevice.search callback to be invoked after every device initialization. Added an async.each callback, following the [async 0.9.2 source](https://github.com/caolan/async/blob/0.9.2/lib/async.js#L115-L137), to call LogicalDevice.search callback when all iterations are complete.
