### PR TITLE
fix for coordinator devices ending up in infamous maybeWrapAsError Exception

### DIFF
--- a/lib/logicalDevice.js
+++ b/lib/logicalDevice.js
@@ -83,7 +83,7 @@ var search = function(callback) {
         // bucket devices by groupid
         devices.forEach(function(device) {
 
-          if (device.name === 'BRIDGE' || device.name === 'BOOST') return; // devices to ignore in search
+          if (device.coordinator === 'false' || device.name === 'BRIDGE' || device.name === 'BOOST') return; // devices to ignore in search
 
           if (!groups[device.group]) groups[device.group] = { members: [] };
 


### PR DESCRIPTION
As documented in https://github.com/stephen/airsonos/issues/216 the 'airsonos' package throws an exception at maybeWrapAsError. This pull request seems to fix this issue in the node-sonos package resulting in a working airsonos package if used with a SONOS setup like PLAYBAR +  two PLAY:1 devices.
